### PR TITLE
feat: Copy ANSI escape sequences directly

### DIFF
--- a/internal/colors/precise.go
+++ b/internal/colors/precise.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const esc = "\\X1B"
+
 type ColorSpace interface {
 	ToPrecise() PreciseColor
 	FromPrecise(PreciseColor) ColorSpace
@@ -39,4 +41,20 @@ func Hex(cs ColorSpace) string {
 		int(math.Round(p.G*255)),
 		int(math.Round(p.B*255)),
 	))
+}
+
+func EscapedSeq(cs ColorSpace, fg bool) string {
+	p := cs.ToPrecise()
+	mod := 38 // fg by default
+	if !fg {
+		mod += 10
+	}
+
+	r := int(math.Round(p.R * 255))
+	g := int(math.Round(p.G * 255))
+	b := int(math.Round(p.B * 255))
+
+	return fmt.Sprintf("%s[%d;2;%d;%d;%dm",
+		esc, mod, r, g, b,
+	)
 }

--- a/internal/switcher/keys.go
+++ b/internal/switcher/keys.go
@@ -7,10 +7,12 @@ import (
 )
 
 const (
-	cpHex  = "x"
-	cpRGB  = "r"
-	cpHSL  = "s"
-	cpCMYK = "c"
+	cpHex   = "x"
+	cpRGB   = "r"
+	cpHSL   = "s"
+	cpCMYK  = "c"
+	cpEscFG = "f"
+	cpEscBG = "b"
 )
 
 type keybinds struct {
@@ -18,6 +20,7 @@ type keybinds struct {
 }
 
 func newKeybinds() keybinds {
+	cpKeys := []string{cpHex, cpRGB, cpHSL, cpCMYK, cpEscBG, cpEscFG}
 	return keybinds{
 		next: key.NewBinding(
 			key.WithKeys("tab"),
@@ -28,9 +31,9 @@ func newKeybinds() keybinds {
 			key.WithHelp("shift+tab", "prev picker"),
 		),
 		copy: key.NewBinding(
-			key.WithKeys(cpHex, cpRGB, cpHSL, cpCMYK),
+			key.WithKeys(cpKeys...),
 			key.WithHelp(
-				strings.Join([]string{cpHex, cpRGB, cpHSL, cpCMYK}, "/"),
+				strings.Join(cpKeys, "/"),
 				"copy color",
 			),
 		),

--- a/internal/switcher/misc.go
+++ b/internal/switcher/misc.go
@@ -8,10 +8,6 @@ import (
 	"github.com/ChausseBenjamin/termpicker/internal/util"
 )
 
-const (
-	okCpMsg = "Copied %s to clipboard as %s"
-)
-
 func (m Model) copyColor(format string) string {
 	pc := m.pickers[m.active].GetColor().ToPrecise()
 	switch format {
@@ -26,6 +22,10 @@ func (m Model) copyColor(format string) string {
 	case cpCMYK:
 		cmyk := colors.CMYK{}.FromPrecise(pc).(colors.CMYK)
 		return util.Copy(cmyk.String())
+	case cpEscFG:
+		return util.Copy(colors.EscapedSeq(m.pickers[m.active].GetColor(), true))
+	case cpEscBG:
+		return util.Copy(colors.EscapedSeq(m.pickers[m.active].GetColor(), false))
 	default:
 		return "Copy format not supported"
 	}


### PR DESCRIPTION
Use the `f` and `b` keys to copy the ANSI escape codes for the foreground and background in the truecolor format. 

For more info: 
https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797 